### PR TITLE
Throw error when DOM and DOW are set

### DIFF
--- a/ccronexpr.c
+++ b/ccronexpr.c
@@ -1653,6 +1653,13 @@ void cron_parse_expr(const char *expression, cron_expr *target, const char **err
     set_number_hits(fields[2], target->hours, 0, CRON_MAX_HOURS, error);
     if (*error) goto return_res;
 
+    // Don't allow specific values for DOM and DOW at the same time
+    if ( ((strcmp(fields[3], "*") != 0) && (strcmp(fields[3], "?") != 0)) &&
+            ((strcmp(fields[5], "*") != 0) && (strcmp(fields[5], "?") != 0)) ) {
+        *error = "Cannot set specific values for day of month AND day of week";
+        goto return_res;
+    }
+
     to_upper(fields[5]);
     days_replaced = replace_ordinals(fields[5], DAYS_ARR, CRON_DAYS_ARR_LEN);
     days_replaced = check_and_replace_h(days_replaced, 5, 1, error);

--- a/ccronexpr_test.c
+++ b/ccronexpr_test.c
@@ -503,8 +503,9 @@ void test_parse() {
     assert(check_same("* * * * 2 *", "* * * * Feb *"));
     assert(check_same("*  *  * *  1 *", "* * * * 1 *"));
     assert(check_same("* * * * 1 L", "* * * * 1 SUN"));
+    // Cannot set specific days of month AND days of week
     assert(check_same("* * * * * *",
-                      "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19-59,H 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18-59,H 0,1,2,3,4,5,6,7,8,9,10,11-23,H 1,2,3,4,5,6,7,8,9,10,11,12,13,14-31,H jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec,H mon,tue,wed,thu,fri,sat,sun,H"));
+                      "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19-59,H 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18-59,H 0,1,2,3,4,5,6,7,8,9,10,11-23,H * jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec,H mon,tue,wed,thu,fri,sat,sun,H"));
     //assert(check_same("0 0 15 1,16,L * *", "0 0 15 1,L,16 * *"));
     //assert(check_expr_valid("0 0 15 1,16,L * *"));
     //assert(check_expr_valid("0 0 15 1,L,16 * *"));
@@ -609,6 +610,11 @@ void test_parse() {
     assert(check_expr_invalid("H H H * H(-1-8) *"));
     assert(check_expr_invalid("0 0\\  0 * * *")); // no "escaping"
     assert(check_expr_invalid("0 0 \\ 0 * * *")); // no "escaping"
+    // Cannot set specific days of month AND days of week
+    assert(check_expr_invalid("0 0 0 1 * 1"));
+    assert(check_expr_invalid("0 0 0 H * SUN"));
+    assert(check_expr_invalid("0 0 0 2 * H"));
+    assert(check_expr_invalid("0 0 0 2W * H"));
 }
 
 void test_bits() {


### PR DESCRIPTION
It shouldn't be supported, but currently is, while the resulting CRONs may execute extremely rarely.
So they should be blocked during parsing (where an error saying what is wrong can be returned) instead of being scheduled far away in the future or not being scheduled and throwing a generic error.